### PR TITLE
Various additions

### DIFF
--- a/src/IntensityMotionCheck.cxx
+++ b/src/IntensityMotionCheck.cxx
@@ -1240,7 +1240,8 @@ bool CIntensityMotionCheck::SliceWiseCheck( DwiImageType::Pointer dwi )
       protocol->GetSliceCheckProtocol().reportFileMode );
     SliceChecker->SetReportType(protocol->GetReportType() );
 
-    SliceChecker->SetQuadFit(0);
+    //  SliceChecker->SetQuadFit(0); 
+    SliceChecker->SetQuadFit(1); //MPH: Changed to turn on quadratic fitting feature (with multiple b-valued data)
     SliceChecker->SetSubRegionalCheck( protocol->GetSliceCheckProtocol().bSubregionalCheck );
     SliceChecker->SetSubregionalCheckRelaxationFactor(
       protocol->GetSliceCheckProtocol().subregionalCheckRelaxationFactor );
@@ -1600,7 +1601,7 @@ bool CIntensityMotionCheck::InterlaceWiseCheck( DwiImageType::Pointer dwi )
       protocol->GetInterlaceCheckProtocol().correlationThresholdBaseline );
     InterlaceChecker->SetCorrelationThresholdGradient(
       protocol->GetInterlaceCheckProtocol().correlationThresholdGradient );
-    InterlaceChecker->SetCorrelationStedvTimesBaseline(
+    InterlaceChecker->SetCorrelationStdevTimesBaseline(
       protocol->GetInterlaceCheckProtocol().correlationDeviationBaseline );
     InterlaceChecker->SetCorrelationStdevTimesGradient(
       protocol->GetInterlaceCheckProtocol().correlationDeviationGradient );

--- a/src/itkDWIQCInterlaceChecker.h
+++ b/src/itkDWIQCInterlaceChecker.h
@@ -79,6 +79,7 @@ public:
     double TranslationZ;
     double Metric;                  // MutualInformation;
     double Correlation;             // graylevel correlation
+    double zScore;        // MPH: Added to store zScore
     } struInterlaceResults,  *pstruInterlaceResults;
 
   /** Standard class typedefs. */
@@ -127,9 +128,9 @@ public:
   itkGetConstMacro( RotationThreshold, float );
   itkSetMacro( RotationThreshold, float );
 
-  /** Get & Set the CorrelationStedvTimesBaseline */
-  itkGetConstMacro( CorrelationStedvTimesBaseline, float );
-  itkSetMacro( CorrelationStedvTimesBaseline, float );
+  /** Get & Set the CorrelationStdevTimesBaseline */
+  itkGetConstMacro( CorrelationStdevTimesBaseline, float );
+  itkSetMacro( CorrelationStdevTimesBaseline, float );
 
   /** Get & Set the CorrelationStdevTimesGradient */
   itkGetConstMacro( CorrelationStdevTimesGradient, float );
@@ -180,14 +181,14 @@ private:
   double interlaceGradientMeans;
   double interlaceGradientDeviations;
 
-  // for all multi-bValued gradient-wise correlation(after quardatic fitting)
-  double quardraticFittedMeans;
-  double quardraticFittedDeviations;
+  // for all multi-bValued gradient-wise correlation (after quadratic fitting)
+  double quadraticFittedMeans;
+  double quadraticFittedDeviations;
 
   /** check parameters */
   float m_CorrelationThresholdBaseline;
   float m_CorrelationThresholdGradient;
-  float m_CorrelationStedvTimesBaseline;
+  float m_CorrelationStdevTimesBaseline;
   float m_CorrelationStdevTimesGradient;
   float m_TranslationThreshold;
   float m_RotationThreshold;

--- a/src/itkDWIQCSliceChecker.h
+++ b/src/itkDWIQCSliceChecker.h
@@ -268,10 +268,9 @@ private:
   std::vector<double> baselineMeans;
   std::vector<double> baselineDeviations;
 
-  /** for all multi-bValued gradient slice wise correlation(after quardatic
-  fitting) */
-  std::vector<double> quardraticFittedMeans;
-  std::vector<double> quardraticFittedDeviations;
+  /** for all multi-bValued gradient slice wise correlation (after quadratic fitting) */
+  std::vector<double> quadraticFittedMeans;
+  std::vector<double> quadraticFittedDeviations;
 
   /** initialize qcResullts */
   std::vector<std::vector<double> > ResultsContainer;      // starts from #1
@@ -325,6 +324,9 @@ private:
 
   std::vector<bool>                 qcResults;
   std::vector<std::vector<double> > normalizedMetric;
+  
+  // MPH: Add capability to report the z-scored correlations (only operative for quadFit feature)
+  std::vector<std::vector<double> > zScoreContainer;
 
   void parseGradientDirections();
 


### PR DESCRIPTION
I have:
1) Fixed a bug in the XtXinv operation of the QuadFit feature of SliceChecker.
2) Added reporting of the zScore computed internally as part of SliceChecker and InterlaceChecker, so that the criterion used internally for deciding whether a gradient is excluded is available in the QCReport.  This is zScore is computed and reported regardless of whether QuadFit is used.
3) Fixed some typos in variable names that were bothering me :)

