### PR TITLE
Remove ambiguous license

### DIFF
--- a/src/DominantDirectional/DominantDirectional_Detector.cxx
+++ b/src/DominantDirectional/DominantDirectional_Detector.cxx
@@ -1,15 +1,7 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Language:  C++
 Author:    Mahshid Farzinfar farzinfa@email.unc.edu
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/DominantDirectional/DominantDirectional_Detector.h
+++ b/src/DominantDirectional/DominantDirectional_Detector.h
@@ -1,15 +1,7 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Language:  C++
 Author:    Mahshid Farzinfar farzinfa@email.unc.edu
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/itkDWIBaselineAverager.h
+++ b/src/itkDWIBaselineAverager.h
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWIBaselineAverger.h $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.4 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/itkDWIBaselineAverager.hxx
+++ b/src/itkDWIBaselineAverager.hxx
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWIBaselineAverger.cpp $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.12 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/itkDWICropper.h
+++ b/src/itkDWICropper.h
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWICropper.h $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.4 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/itkDWICropper.hxx
+++ b/src/itkDWICropper.hxx
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWICropper.cpp $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.8 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 #ifndef _itkDWICropper_cpp

--- a/src/itkDWIEddyCurrentHeadMotionCorrector.h
+++ b/src/itkDWIEddyCurrentHeadMotionCorrector.h
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWIEddyCurrentHeadMotionCorrector.h $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.4 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/itkDWIEddyCurrentHeadMotionCorrector.hxx
+++ b/src/itkDWIEddyCurrentHeadMotionCorrector.hxx
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWIEddyCurrentHeadMotionCorrector.cpp $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.9 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/itkDWIQCGradientChecker.h
+++ b/src/itkDWIQCGradientChecker.h
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWIQCGradientChecker.h $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.6 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/itkDWIQCGradientChecker.hxx
+++ b/src/itkDWIQCGradientChecker.hxx
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWIQCGradientChecker.cpp $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.10 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/itkDWIQCInterlaceChecker.h
+++ b/src/itkDWIQCInterlaceChecker.h
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWIQCInterlaceChecker.h $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.4 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/itkDWIQCInterlaceChecker.hxx
+++ b/src/itkDWIQCInterlaceChecker.hxx
@@ -1,18 +1,10 @@
 /*=========================================================================
 
- Program:   NeuroLib
  Module:    $file: itkDWIQCInterlaceChecker.cpp $
  Language:  C++
  Date:      $Date: 2009-11-26 21:52:35 $
  Version:   $Revision: 1.10 $
  Author:    Zhexing Liu (liuzhexing@gmail.com)
-
- Copyright (c) NIRAL, UNC. All rights reserved.
- See http://www.niral.unc.edu for details.
-
- This software is distributed WITHOUT ANY WARRANTY; without even
- the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- PURPOSE.  See the above copyright notices for more information.
 
  =========================================================================*/
 

--- a/src/itkDWIQCSliceChecker.h
+++ b/src/itkDWIQCSliceChecker.h
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWIQCSliceChecker.h $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.7 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 

--- a/src/itkDWIQCSliceChecker.hxx
+++ b/src/itkDWIQCSliceChecker.hxx
@@ -1,18 +1,10 @@
 /*=========================================================================
 
-Program:   NeuroLib
 Module:    $file: itkDWIQCSliceChecker.cpp $
 Language:  C++
 Date:      $Date: 2009-11-26 21:52:35 $
 Version:   $Revision: 1.11 $
 Author:    Zhexing Liu (liuzhexing@gmail.com)
-
-Copyright (c) NIRAL, UNC. All rights reserved.
-See http://www.niral.unc.edu for details.
-
-This software is distributed WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
 


### PR DESCRIPTION
In some file a different license was listed. 
The only license that should be mentioned is in the root folder. License.txt