### PR TITLE
Update DTIPrep dependencies. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 
 # emacs backup files
 *~
+CMakeLists.txt.user

--- a/SuperBuild/External_BRAINSTools.cmake
+++ b/SuperBuild/External_BRAINSTools.cmake
@@ -129,7 +129,7 @@ if(NOT ( DEFINED "${extProjName}_SOURCE_DIR" OR ( DEFINED "USE_SYSTEM_${extProjN
       -DUSE_SYSTEM_ZLIB:BOOL=ON
       -Dzlib_DIR:PATH=${zlib_DIR}
       -DZLIB_ROOT:PATH=${zlib_DIR}
-      -DZLIB_INCLUDE_DIR:PATH=${zlib}_DIR}/include
+      -DZLIB_INCLUDE_DIR:PATH=${zlib_DIR}/include
       -DZLIB_LIBRARY:FILEPATH=${ZLIB_LIBRARY}
       -DUSE_BRAINSABC:BOOL=OFF
       -DUSE_BRAINSConstellationDetector:BOOL=OFF
@@ -167,7 +167,7 @@ if(NOT ( DEFINED "${extProjName}_SOURCE_DIR" OR ( DEFINED "USE_SYSTEM_${extProjN
 
   ### --- End Project specific additions
   set(${proj}_REPOSITORY "${git_protocol}://github.com/BRAINSia/BRAINSTools.git")
-  set(${proj}_GIT_TAG 33b739e7e6a414be41d44aca028b1304a2c0a440 )
+  set(${proj}_GIT_TAG 4aef8f72e4ee2f26020e75c73580f56a9eda3a97 )
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}

--- a/SuperBuild/External_BRAINSTools.cmake
+++ b/SuperBuild/External_BRAINSTools.cmake
@@ -167,7 +167,7 @@ if(NOT ( DEFINED "${extProjName}_SOURCE_DIR" OR ( DEFINED "USE_SYSTEM_${extProjN
 
   ### --- End Project specific additions
   set(${proj}_REPOSITORY "${git_protocol}://github.com/BRAINSia/BRAINSTools.git")
-  set(${proj}_GIT_TAG 4aef8f72e4ee2f26020e75c73580f56a9eda3a97 )
+  set(${proj}_GIT_TAG b5e27412868ec9834814318fac3b04e3de95b451 )
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}

--- a/SuperBuild/External_DTIProcess.cmake
+++ b/SuperBuild/External_DTIProcess.cmake
@@ -73,12 +73,12 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
     -DDTIProcess_SUPERBUILD:BOOL=OFF
     -DEXECUTABLES_ONLY:BOOL=ON
     -DSubversion_SVN_EXECUTABLE:PATH=${SVNCOMMAND}
-    -D
+    -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/${proj}-install
     )
 
   ### --- End Project specific additions
   set( ${proj}_REPOSITORY ${git_protocol}://github.com/NIRALUser/DTIProcessToolkit.git)
-  set( ${proj}_GIT_TAG  863e5da765bb1177d34134b2d65f9212915410d1 )
+  set( ${proj}_GIT_TAG  da1615225b72eb99d9b3d3cebe075112d0c4008c )
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}
@@ -93,13 +93,10 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
     CMAKE_ARGS
       ${CMAKE_OSX_EXTERNAL_PROJECT_ARGS}
       ${COMMON_EXTERNAL_PROJECT_ARGS}
-      ${${proj}_CMAKE_OPTIONS}
-      ## We really do want to install to remove uncertainty about where the tools are
-      ## (on Windows, tools might be in subfolders, like "Release", "Debug",...)
-      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/${proj}-install
+      ${${proj}_CMAKE_OPTIONS}      
     DEPENDS
       ${${proj}_DEPENDENCIES}    
-  )
+  )  
   set(${extProjName}_DIR ${EXTERNAL_BINARY_DIRECTORY}/${proj}-build)
 else()
   if(${USE_SYSTEM_${extProjName}})

--- a/SuperBuild/External_DTIProcess.cmake
+++ b/SuperBuild/External_DTIProcess.cmake
@@ -72,11 +72,13 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
     -DUSE_SYSTEM_SlicerExecutionModel:BOOL=ON
     -DDTIProcess_SUPERBUILD:BOOL=OFF
     -DEXECUTABLES_ONLY:BOOL=ON
+    -DSubversion_SVN_EXECUTABLE:PATH=${SVNCOMMAND}
+    -D
     )
 
   ### --- End Project specific additions
   set( ${proj}_REPOSITORY ${git_protocol}://github.com/NIRALUser/DTIProcessToolkit.git)
-  set( ${proj}_GIT_TAG a7c39e485e492bc6b72f72348939d47835cd56cc )
+  set( ${proj}_GIT_TAG  863e5da765bb1177d34134b2d65f9212915410d1 )
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}
@@ -94,10 +96,9 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
       ${${proj}_CMAKE_OPTIONS}
       ## We really do want to install to remove uncertainty about where the tools are
       ## (on Windows, tools might be in subfolders, like "Release", "Debug",...)
-      -DCMAKE_INSTALL_PREFIX:PATH=${EXTERNAL_BINARY_DIRECTORY}/${proj}-install
+      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/${proj}-install
     DEPENDS
-      ${${proj}_DEPENDENCIES}
-    INSTALL_COMMAND ""
+      ${${proj}_DEPENDENCIES}    
   )
   set(${extProjName}_DIR ${EXTERNAL_BINARY_DIRECTORY}/${proj}-build)
 else()

--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -33,7 +33,7 @@ set(${extProjName}_REQUIRED_VERSION ${${extProjName}_VERSION_MAJOR})  #If a requ
 #if(DEFINED ${extProjName}_DIR AND NOT EXISTS ${${extProjName}_DIR})
 #  message(FATAL_ERROR "${extProjName}_DIR variable is defined but corresponds to non-existing directory (${${extProjName}_DIR})")
 #endif()
-set(${proj}_DEPENDENCIES "")
+set(${proj}_DEPENDENCIES "VTK")
 
 if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" ) )
   #message(STATUS "${__indent}Adding project ${proj}")
@@ -159,6 +159,8 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
       -DITK_WRAPPING:BOOL=OFF #${BUILD_SHARED_LIBS} ## HACK:  QUICK CHANGE
       -DITK_USE_SYSTEM_DCMTK:BOOL=${${PROJECT_NAME}_BUILD_DICOM_SUPPORT}
       -DModule_ITKIOPhilipsREC:BOOL=ON
+      -DModule_ITKVtkGlue:BOOL=ON
+      -DVTK_DIR:PATH=${VTK_DIR}
       ${${proj}_TIFF_ARGS}
       ${${proj}_JPEG_ARGS}
       ${${proj}_ZLIB_ARGS}
@@ -170,8 +172,8 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
     )
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://itk.org/ITK.git)
-  set(${proj}_GIT_TAG 9dc4f194046cedb4b392e181caec73b629ae7564)
-  set(ITK_VERSION_ID ITK-4.6)
+  set(${proj}_GIT_TAG 74155d0b7059fde841832c92a9aec78c79bc68c0)
+  set(ITK_VERSION_ID ITK-4.8)
 
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -24,33 +24,7 @@ ProjectDependancyPush(CACHED_proj ${proj})
 set(extProjName VTK) #The find_package known name
 set(proj        VTK) #This local name
 
-
-#Setting VTK_VERSION_MAJOR to its default value if it has not been set before
-set(VTK_VERSION_MAJOR 5 CACHE STRING "Choose the expected VTK major version to build Slicer (5 or 6).")
-# Set the possible values of VTK major version for cmake-gui
-set_property(CACHE VTK_VERSION_MAJOR PROPERTY STRINGS "5" "6")
-if(NOT "${VTK_VERSION_MAJOR}" STREQUAL "5" AND NOT "${VTK_VERSION_MAJOR}" STREQUAL "6")
-  set(VTK_VERSION_MAJOR 5 CACHE STRING "Choose the expected VTK major version to build Slicer (5 or 6)." FORCE)
-  message(WARNING "Setting VTK_VERSION_MAJOR to '5' as an valid value was specified.")
-endif()
-
-set(USE_VTKv5 ON)
-set(USE_VTKv6 OFF)
-if(${VTK_VERSION_MAJOR} STREQUAL "6")
-  set(USE_VTKv5 OFF)
-  set(USE_VTKv6 ON)
-endif()
-
-if(USE_VTKv6)
-  set(${extProjName}_REQUIRED_VERSION "6.1")  #If a required version is necessary, then set this, else leave blank
-else()
-  set(${extProjName}_REQUIRED_VERSION "5.10")  #If a required version is necessary, then set this, else leave blank
-endif()
-
-# Sanity checks
-#if(DEFINED ${extProjName}_DIR AND NOT EXISTS ${${extProjName}_DIR})
-#  message(FATAL_ERROR "${extProjName}_DIR variable is defined but corresponds to non-existing directory (${${extProjName}_DIR})")
-#endif()
+set(${extProjName}_REQUIRED_VERSION "6.1")  #If a required version is necessary, then set this, else leave blank
 
 # Set dependency list
 set(${proj}_DEPENDENCIES "")
@@ -96,13 +70,9 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
 
   set(VTK_QT_ARGS)
   if(${PRIMARY_PROJECT_NAME}_USE_QT)
-    if(USE_VTKv6)
-      set(VTK_QT_ARGS
-        -DModule_vtkGUISupportQt:BOOL=ON
-        )
-    else()
-      set(VTK_QT_ARGS)
-    endif()
+    set(VTK_QT_ARGS
+      -DModule_vtkGUISupportQt:BOOL=ON
+    )
     if(NOT APPLE)
       list(APPEND VTK_QT_ARGS
         #-DDESIRED_QT_VERSION:STRING=4 # Unused
@@ -190,13 +160,10 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
       ${VTK_MAC_ARGS}
     )
   ### --- End Project specific additions
-if(USE_VTKv6)
+
   set(${proj}_GIT_TAG "v6.1.0")
   set(${proj}_REPOSITORY ${git_protocol}://vtk.org/VTK.git)
-else()
-  set(${proj}_REPOSITORY ${git_protocol}://github.com/BRAINSia/VTK.git)
-  set(${proj}_GIT_TAG "FixClangFailure_VTK5.10_release")
-endif()
+
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}
@@ -226,15 +193,11 @@ endif()
     DEPENDERS configure
     COMMAND ${CMAKE_COMMAND}
     -DVTKSource=<SOURCE_DIR>
-    -DUSE_VTKv6=${USE_VTKv6}
+    -DUSE_VTKv6=ON
     -P ${VTKPatchScript}
     )
 
-if(USE_VTKv6)
-  set(${extProjName}_DIR ${CMAKE_BINARY_DIR}/${proj}-install/lib/cmake/vtk-6.1)
-else()
-  set(${extProjName}_DIR ${CMAKE_BINARY_DIR}/${proj}-install/lib/vtk-5.10)
-endif()
+set(${extProjName}_DIR ${CMAKE_BINARY_DIR}/${proj}-install/lib/cmake/vtk-6.1)
 
 else()
   if(${USE_SYSTEM_${extProjName}})

--- a/SuperBuild/External_niral_utilities.cmake
+++ b/SuperBuild/External_niral_utilities.cmake
@@ -77,7 +77,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
 
   ### --- End Project specific additions
   set( ${proj}_REPOSITORY ${git_protocol}://github.com/NIRALUser/niral_utilities.git )
-  set( ${proj}_GIT_TAG 8034509e6598e06842a668e051b8ca84842fcd0c)
+  set( ${proj}_GIT_TAG 6924bab40c14705e67da0b0fe6292a0253b241c5)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}


### PR DESCRIPTION
- Use VTK6 by default. 
- VTK5 for DTIPrep is deprecated. 

- Update dependencies for DTIProcess and niral_utilities

Future work: 
Support for Qt5, deprecate support for Qt4
