### PR TITLE
DTIPrepTools: Remove reference to retired data server

### DIFF
--- a/DTIPrepTools.cmake
+++ b/DTIPrepTools.cmake
@@ -171,8 +171,6 @@ list(APPEND ExternalData_URL_TEMPLATES
   ## This server is now obsolete "http://www.psychiatry.uiowa.edu/users/brainstestdata/ctestdata/%(algo)/%(hash)"
   ## The primary new home for data
   "http://slicer.kitware.com/midas3/api/rest?method=midas.bitstream.download&checksum=%(hash)"
-  # Data published by MIDAS
-  "http://midas.kitware.com/api/rest/midas.bitstream.by.hash?hash=%(hash)&algorithm=%(algo)"
   # Data published by developers using git-gerrit-push.
   "http://www.itk.org/files/ExternalData/%(algo)/%(hash)"
 )


### PR DESCRIPTION
midas.kitware.com is retired
See https://discourse.slicer.org/t/retiring-midas-kitware-com-data-repository/2243